### PR TITLE
Changed the manner in which messages and tags are inputted in transactions for usability.

### DIFF
--- a/app/src/main/java/org/iota/wallet/ui/fragment/GenerateQRCodeFragment.java
+++ b/app/src/main/java/org/iota/wallet/ui/fragment/GenerateQRCodeFragment.java
@@ -113,6 +113,9 @@ public class GenerateQRCodeFragment extends Fragment implements View.OnClickList
         switch (view.getId()) {
             case R.id.generate_qr_code_fab_button:
 
+                final String msg = getMessage().toUpperCase();
+                final String tag = getTaG().toUpperCase();
+
                 //reset errors
                 addressEditTextInputLayout.setError(null);
                 messageEditTextInputLayout.setError(null);
@@ -121,10 +124,10 @@ public class GenerateQRCodeFragment extends Fragment implements View.OnClickList
                 if (!InputValidator.isAddress(getAddress())) {
                     addressEditTextInputLayout.setError(getString(R.string.messages_enter_txaddress));
 
-                } else if (!InputValidator.isTrytes(getMessage(), getMessage().length()) && !getMessage().equals(getMessage().toUpperCase())) {
+                } else if (!InputValidator.isTrytes(msg, msg.length())) {
                     messageEditTextInputLayout.setError(getString(R.string.messages_invalid_characters));
 
-                } else if (!InputValidator.isTrytes(getTaG(), getTaG().length()) && !getTaG().equals(getTaG().toUpperCase())) {
+                } else if (!InputValidator.isTrytes(tag, tag.length())) {
                     tagEditTextInputLayout.setError(getString(R.string.messages_invalid_characters));
 
                 } else {

--- a/app/src/main/java/org/iota/wallet/ui/fragment/NewTransferFragment.java
+++ b/app/src/main/java/org/iota/wallet/ui/fragment/NewTransferFragment.java
@@ -221,6 +221,9 @@ public class NewTransferFragment extends Fragment implements View.OnClickListene
             case R.id.new_transfer_send_fab_button:
                 SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
 
+                final String msg = getMessage().toUpperCase();
+                final String tag = getTaG().toUpperCase();
+                
                 addressEditTextInputLayout.setError(null);
                 tagEditTextInputLayout.setError(null);
                 amountEditTextInputLayout.setError(null);
@@ -235,13 +238,13 @@ public class NewTransferFragment extends Fragment implements View.OnClickListene
                 } else if (prefs.getLong(Constants.PREFERENCES_CURRENT_IOTA_BALANCE, 0) < Long.parseLong(amountInSelectedUnit())) {
                     amountEditTextInputLayout.setError(getString(R.string.messages_not_enough_balance));
 
-                } else if (!InputValidator.isTrytes(getMessage(), getMessage().length()) && !getMessage().equals(getMessage().toUpperCase())) {
+                } else if (!InputValidator.isTrytes(msg, msg.length())) {
                     messageEditTextInputLayout.setError(getString(R.string.messages_invalid_characters));
 
-                } else if (!InputValidator.isTrytes(getTaG(), getTaG().length()) && !getTaG().equals(getTaG().toUpperCase())) {
+                } else if (!InputValidator.isTrytes(tag, tag.length())) {
                     tagEditTextInputLayout.setError(getString(R.string.messages_invalid_characters));
 
-                } else if (getTaG().length() > 27) {
+                } else if (tag.length() > 27) {
                     tagEditTextInputLayout.setError(getString(R.string.messages_tag_to_long));
 
                 } else {
@@ -256,7 +259,7 @@ public class NewTransferFragment extends Fragment implements View.OnClickListene
                             new DialogInterface.OnClickListener() {
                                 public void onClick(DialogInterface dialog, int which) {
                                     SendTransferRequest tir = new SendTransferRequest(getAddress(),
-                                            amountInSelectedUnit(), getMessage(), getTaG());
+                                            amountInSelectedUnit(), msg, tag);
 
                                     TaskManager rt = new TaskManager(getActivity());
                                     rt.startNewRequestTask(tir);
@@ -317,7 +320,6 @@ public class NewTransferFragment extends Fragment implements View.OnClickListene
                         Constants.REQUEST_CAMERA_PERMISSION);
 
             } else {
-
                 //Camera permissions have not been granted yet so request them directly
                 this.requestPermissions(new String[]{Manifest.permission.CAMERA},
                         Constants.REQUEST_CAMERA_PERMISSION);

--- a/app/src/main/res/layout/fragment_generate_qr.xml
+++ b/app/src/main/res/layout/fragment_generate_qr.xml
@@ -94,7 +94,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/message_optional"
-                    android:inputType="text" />
+                    android:inputType="text" 
+                    android:digits="abddefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ9" />
 
             </android.support.design.widget.TextInputLayout>
 
@@ -112,7 +113,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/tag_optional"
-                    android:inputType="text" />
+                    android:inputType="text" 
+                    android:digits="abddefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ9" />
 
             </android.support.design.widget.TextInputLayout>
 

--- a/app/src/main/res/layout/fragment_new_transfer.xml
+++ b/app/src/main/res/layout/fragment_new_transfer.xml
@@ -98,7 +98,9 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/message_optional"
-                    android:inputType="text" />
+                    android:inputType="text" 
+                    android:digits="abddefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ9"
+                    />
 
             </android.support.design.widget.TextInputLayout>
 
@@ -116,7 +118,9 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/tag_optional"
-                    android:inputType="text" />
+                    android:inputType="text" 
+                    android:digits="abddefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ9"
+                    />
 
             </android.support.design.widget.TextInputLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,8 +33,8 @@
     <string name="address">Address</string>
     <string name="hash">Hash</string>
     <string name="amount">Amount</string>
-    <string name="message_optional">Message (optional)</string>
-    <string name="tag_optional">Tag (optional)</string>
+    <string name="message_optional">Message (optional, A-Z and 9 only)</string>
+    <string name="tag_optional">Tag (optional, A-Z and 9 only)</string>
     <string name="neighbor_ip">Neighbor IP:</string>
 
     <!-- Buttons-->


### PR DESCRIPTION
App only allows the input of A-Z characters and the number 9 into the Message and Tag fields of the transaction fragment screens. This improves the user experience of entering text into the Message and Tag fields of the transaction screens. Text is automatically converted to upper case when successful validation and transmission is called. Needs localization to other languages.